### PR TITLE
Update addrequestheader.adoc

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/addrequestheader.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/addrequestheader.adoc
@@ -30,8 +30,10 @@ class RouteConfiguration {
 
     @Bean
     public RouterFunction<ServerResponse> gatewayRouterFunctionsAddReqHeader() {
-        return route(GET("/red"), http("https://example.org"))
-                .before(addRequestHeader("X-Request-red", "blue"));
+        return route("addRequestHeader")
+                .route(GET("/red"), http("https://example.org"))
+                .before(addRequestHeader("X-Request-red", "blue"))
+                .build();
     }
 }
 ----
@@ -50,8 +52,10 @@ class RouteConfiguration {
 
     @Bean
     public RouterFunction<ServerResponse> gatewayRouterFunctionsAddReqHeader() {
-        return route(GET("/red/{segment}"), http("https://example.org"))
-                .before(addRequestHeader("X-Request-red", "blue-{segment}"));
+        return route("addRequestHeader")
+                .route(GET("/red/{segment}"), http("https://example.org"))
+                .before(addRequestHeader("X-Request-red", "blue-{segment}"))
+                .build();
     }
 }
 ----


### PR DESCRIPTION
After reading the following documentation, I was getting error over before method - The method before(Function<ServerRequest,ServerRequest>) is undefined for the type RouterFunction.

Using this java-based configuration it solved the error.

This solves the issue- [#3700](https://github.com/spring-cloud/spring-cloud-gateway/issues/3700)